### PR TITLE
[Release 0.1.7] Replace bound references to old objects in memory in order to support imports in the form 'from module import obj'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@
 pip
 
 ```bash
-pip install pybond==0.1.6
+pip install pybond==0.1.7
 ```
 
 requirements.txt
 
 ```python
-pybond==0.1.6
+pybond==0.1.7
 ```
 
 pyproject.toml
 
 ```toml
-pybond = "0.1.6"
+pybond = "0.1.7"
 ```
 
 ## Example usage

--- a/pybond/memory.py
+++ b/pybond/memory.py
@@ -1,11 +1,18 @@
 from gc import collect, get_referrers
+from typing import Any
+
+from pytest import MonkeyPatch
 
 
 def _is_referrer_a_module(d: dict) -> bool:
     return isinstance(d, dict) and "__loader__" in d.keys()
 
 
-def replace_bound_references_in_memory(monkeypatch_ctx, target_obj, new_obj):
+def replace_bound_references_in_memory(
+    monkeypatch_ctx: MonkeyPatch,
+    target_obj: Any,
+    new_obj: Any,
+) -> None:
     collect()  # Perform GC before checking for references in memory
     for reference in get_referrers(target_obj):
         if _is_referrer_a_module(reference):

--- a/pybond/memory.py
+++ b/pybond/memory.py
@@ -1,0 +1,14 @@
+from gc import collect, get_referrers
+
+
+def _is_referrer_a_module(d: dict) -> bool:
+    return isinstance(d, dict) and "__loader__" in d.keys()
+
+
+def replace_bound_references_in_memory(monkeypatch_ctx, target_obj, new_obj):
+    collect()  # Perform GC before checking for references in memory
+    for reference in get_referrers(target_obj):
+        if _is_referrer_a_module(reference):
+            for k, v in reference.items():
+                if v is target_obj:
+                    monkeypatch_ctx.setitem(reference, k, new_obj)

--- a/pybond/types.py
+++ b/pybond/types.py
@@ -1,0 +1,16 @@
+from types import ModuleType
+from typing import Any, Callable, Tuple, TypeAlias, TypedDict
+
+FunctionCall = TypedDict(
+    "FunctionCall",
+    {
+        "args": list[Any],
+        "kwargs": dict[str, Any],
+        "error": Any,
+        "return": Any,
+    }
+)
+
+Spyable: TypeAlias = Callable | object
+SpyTarget: TypeAlias = Tuple[ModuleType, str]
+StubTarget: TypeAlias = Tuple[ModuleType, str, Spyable]

--- a/pybond/util.py
+++ b/pybond/util.py
@@ -1,4 +1,5 @@
 from inspect import getfullargspec
+from typing import Callable
 
 
 def _args_match(fsig, gsig) -> bool:
@@ -62,5 +63,5 @@ def function_signatures_match(f, g):
             raise
 
 
-def is_wrapped_function(f):
+def is_wrapped_function(f: Callable) -> bool:
     return hasattr(f, "__wrapped__")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybond"
-version = "0.1.6"
+version = "0.1.7"
 description = "pybond is a spying and stubbing library inspired by the clojure bond library."
 authors = ["Guillaume Pelletier <guigui.p@gmail.com>"]
 license = "Eclipse Public License - v 1.0"

--- a/sample_code/my_module.py
+++ b/sample_code/my_module.py
@@ -1,13 +1,7 @@
 import datetime
-from datetime import datetime as datetime_2
 from typing import Any
 
 import sample_code.other_package as other_package
-from sample_code.other_package import (
-    make_a_network_request as make_a_network_request_2,
-    write_to_disk as write_to_disk_2,
-    dangerous_function as dangerous_function_2,
-)
 
 
 def foo(x: Any) -> None:
@@ -16,18 +10,8 @@ def foo(x: Any) -> None:
     return response
 
 
-def foo_2(x: Any) -> None:
-    response = make_a_network_request_2(x, y=None)
-    write_to_disk_2(response)
-    return response
-
-
 def bar(x: Any) -> None:
     return foo(x)
-
-
-def bar_2(x: Any) -> None:
-    return foo_2(x)
 
 
 def try_dangerous_things():
@@ -37,15 +21,5 @@ def try_dangerous_things():
         return e
 
 
-def try_dangerous_things_2():
-    try:
-        return dangerous_function_2()
-    except Exception as e:
-        return e
-
-
 def use_the_datetime_class_to_get_current_timestamp():
     return datetime.datetime.now()
-
-def use_the_datetime_class_to_get_current_timestamp_2():
-    return datetime_2.now()

--- a/sample_code/my_module.py
+++ b/sample_code/my_module.py
@@ -1,7 +1,13 @@
 import datetime
+from datetime import datetime as datetime_2
 from typing import Any
 
 import sample_code.other_package as other_package
+from sample_code.other_package import (
+    make_a_network_request as make_a_network_request_2,
+    write_to_disk as write_to_disk_2,
+    dangerous_function as dangerous_function_2,
+)
 
 
 def foo(x: Any) -> None:
@@ -10,8 +16,18 @@ def foo(x: Any) -> None:
     return response
 
 
+def foo_2(x: Any) -> None:
+    response = make_a_network_request_2(x, y=None)
+    write_to_disk_2(response)
+    return response
+
+
 def bar(x: Any) -> None:
     return foo(x)
+
+
+def bar_2(x: Any) -> None:
+    return foo_2(x)
 
 
 def try_dangerous_things():
@@ -21,5 +37,15 @@ def try_dangerous_things():
         return e
 
 
+def try_dangerous_things_2():
+    try:
+        return dangerous_function_2()
+    except Exception as e:
+        return e
+
+
 def use_the_datetime_class_to_get_current_timestamp():
     return datetime.datetime.now()
+
+def use_the_datetime_class_to_get_current_timestamp_2():
+    return datetime_2.now()

--- a/sample_code/my_module_with_bound_imports.py
+++ b/sample_code/my_module_with_bound_imports.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Any
+
+from sample_code.other_package import (
+    make_a_network_request,
+    write_to_disk,
+    dangerous_function,
+)
+
+
+def foo(x: Any) -> None:
+    response = make_a_network_request(x, y=None)
+    write_to_disk(response)
+    return response
+
+
+def bar(x: Any) -> None:
+    return foo(x)
+
+
+def try_dangerous_things():
+    try:
+        return dangerous_function()
+    except Exception as e:
+        return e
+
+
+def use_the_datetime_class_to_get_current_timestamp():
+    return datetime.now()

--- a/tests/pybond/test_assertions.py
+++ b/tests/pybond/test_assertions.py
@@ -19,10 +19,10 @@ def test_was_called():
         my_module.bar(42)
         assert was_called(my_module.foo)
 
-    with spy([my_module, "foo"]):
+    with spy((my_module, "foo")):
         run_tests()
 
-    with stub([my_module, "foo", my_module.foo]):
+    with stub((my_module, "foo", my_module.foo)):
         run_tests()
 
 
@@ -43,10 +43,10 @@ def test_times_called():
         my_module.bar(42)
         assert times_called(my_module.foo, 4)
 
-    with spy([my_module, "foo"]):
+    with spy((my_module, "foo")):
         run_tests()
 
-    with stub([my_module, "foo", my_module.foo]):
+    with stub((my_module, "foo", my_module.foo)):
         run_tests()
 
 
@@ -59,7 +59,7 @@ def test_times_called_throws_on_unspied_functions():
 
 def test_called_with_args():
     # When there is only one function call
-    with spy([other_package, "make_a_network_request"]):
+    with spy((other_package, "make_a_network_request")):
         assert not called_with_args(
             other_package.make_a_network_request,
             args=[42, 12],
@@ -73,7 +73,7 @@ def test_called_with_args():
         )
 
     # When there are multiple function calls (order doesn't matter)
-    with spy([other_package, "make_a_network_request"]):
+    with spy((other_package, "make_a_network_request")):
         other_package.make_a_network_request(0, y=None)
         other_package.make_a_network_request(0, y="elephant")
         other_package.make_a_network_request(42, 12, y="y", other_arg=True)
@@ -118,7 +118,7 @@ def test_called_with_args_throws_on_unspied_functions():
 
 def test_called_exactly_once_with_args():
     # When there is only one function call
-    with spy([other_package, "make_a_network_request"]):
+    with spy((other_package, "make_a_network_request")):
         assert not called_exactly_once_with_args(
             other_package.make_a_network_request,
             args=[42, 12],
@@ -132,7 +132,7 @@ def test_called_exactly_once_with_args():
         )
 
     # When there are multiple function calls (order doesn't matter)
-    with spy([other_package, "make_a_network_request"]):
+    with spy((other_package, "make_a_network_request")):
         other_package.make_a_network_request(0, y=None)
         other_package.make_a_network_request(0, y="elephant")
         other_package.make_a_network_request(42, 12, y="y", other_arg=True)
@@ -177,7 +177,7 @@ def test_called_exactly_once_with_args_throws_on_unspied_functions():
 
 def test_called_with_exact_args_list():
     # When there is only one function call
-    with spy([other_package, "make_a_network_request"]):
+    with spy((other_package, "make_a_network_request")):
         assert not called_with_exact_args_list(
             other_package.make_a_network_request,
         )
@@ -189,7 +189,7 @@ def test_called_with_exact_args_list():
         )
 
     # When there are multiple function calls (order matters)
-    with spy([other_package, "make_a_network_request"]):
+    with spy((other_package, "make_a_network_request")):
         other_package.make_a_network_request(0, y=None)
         other_package.make_a_network_request(0, y="elephant")
         other_package.make_a_network_request(42, 12, y="y", other_arg=True)

--- a/tests/pybond/test_james.py
+++ b/tests/pybond/test_james.py
@@ -6,14 +6,13 @@ import sample_code.my_module as my_module
 import sample_code.other_package as other_package
 from tests.sample_code.mocks import create_mock_datetime
 from pybond import calls, spy, stub
+from pybond.james import _instrumented_obj
 
 
 def test_spied_function_throws_exception():
     def run_tests():
-        assert (
-            my_module.try_dangerous_things().args[0]
-            == "This is what happens when you don't floss!"
-        )
+        exception = my_module.try_dangerous_things()
+        assert exception.args[0] == "This is what happens when you don't floss!"
         assert (
             "This is what happens when you don't floss!" in [
                 call["error"][1].args[0]
@@ -65,3 +64,38 @@ def test_class_stubbing():
             my_module.use_the_datetime_class_to_get_current_timestamp()
             == mock_now
         )
+
+
+@pytest.mark.parametrize(
+    "original_obj, stub_obj, error_message",
+    [
+        pytest.param(
+            other_package.write_to_disk,
+            lambda _: None,
+            None,
+        ),
+        pytest.param(
+            other_package.write_to_disk,
+            lambda _, __: None,
+            "Stub does not match the signature of write_to_disk.",
+        ),
+        pytest.param(
+            other_package.write_to_disk,
+            "This is not a Callable, it's a string.",
+            "pybond expected a Callable type.",
+        ),
+        pytest.param(
+            "This is not a Callable, it's a string.",
+            "This is not a Callable, it's a string.",
+            "Object of type <class 'str'> is not supported by pybond."
+        )
+    ],
+)
+def test_instrumented_obj(original_obj, stub_obj, error_message):
+    if not error_message:
+        _instrumented_obj(original_obj, stub_obj)
+        assert True
+    else:
+        with pytest.raises(Exception) as e:
+            _instrumented_obj(original_obj, stub_obj)
+        assert error_message in e.value.args[0]

--- a/tests/pybond/test_james.py
+++ b/tests/pybond/test_james.py
@@ -21,10 +21,10 @@ def test_spied_function_throws_exception():
             ]
         )
 
-    with spy([other_package, "dangerous_function"]):
+    with spy((other_package, "dangerous_function")):
         run_tests()
     
-    with stub([other_package, "dangerous_function", other_package.dangerous_function]):
+    with stub((other_package, "dangerous_function", other_package.dangerous_function)):
         run_tests()
 
 
@@ -47,19 +47,19 @@ def test_stub_function_signature_should_match(
     signature_matching,
 ):
     if signature_matching:
-        with stub([target_module, target_function, stub_fn]):
+        with stub((target_module, target_function, stub_fn)):
             my_module.bar(42)
             assert True  # No exception is thrown in the line above
     else:
         with pytest.raises(Exception) as e:
-            with stub([target_module, target_function, stub_fn]):
+            with stub((target_module, target_function, stub_fn)):
                 my_module.bar(42)
         assert e.value.args[0].startswith("Stub does not match the signature of")
 
 
 def test_class_stubbing():
     mock_now = datetime.datetime.now()
-    with stub([datetime, "datetime", create_mock_datetime(mock_now)]):
+    with stub((datetime, "datetime", create_mock_datetime(mock_now))):
         time.sleep(2)
         assert (
             my_module.use_the_datetime_class_to_get_current_timestamp()

--- a/tests/sample_code/test_decorators.py
+++ b/tests/sample_code/test_decorators.py
@@ -3,5 +3,5 @@ import sample_code.decorators as decorators
 
 
 def test_decorated_functions():
-    with stub([decorators, "my_adder", lambda a, b: a * b]):
+    with stub((decorators, "my_adder", lambda a, b: a * b)):
         assert decorators.my_adder(2, 3) == 6

--- a/tests/sample_code/test_my_module.py
+++ b/tests/sample_code/test_my_module.py
@@ -2,7 +2,7 @@ from pybond import calls, called_with_args, spy, stub, times_called
 
 import sample_code.other_package as other_package
 import sample_code.my_module as my_module
-from sample_code.my_module import bar
+from sample_code.my_module import bar, bar_2
 from tests.sample_code.mocks import (
     mock_make_a_network_request,
     mock_write_to_disk,
@@ -61,3 +61,48 @@ def test_bar_handles_response():
                 "error": None,
             },
         ]
+
+
+def test_bar_handles_response_2():
+    with stub(
+        [other_package, "make_a_network_request", mock_make_a_network_request],
+        [other_package, "write_to_disk", mock_write_to_disk],
+    ), spy(
+        [my_module, "foo_2"],
+    ):
+        assert times_called(my_module.foo_2, 0)
+        assert times_called(other_package.make_a_network_request, 0)
+        assert bar_2(21) == {"result": 42}
+        assert times_called(my_module.foo_2, 1)
+        assert times_called(other_package.make_a_network_request, 1)
+        assert called_with_args(my_module.foo_2, args=[21])
+        assert bar_2(20) == {"result": 40}
+        assert calls(my_module.foo_2) == [
+            {
+                "args": [21],
+                "kwargs": None,
+                "return": {"result": 42},
+                "error": None,
+            },
+            {
+                "args": [20],
+                "kwargs": None,
+                "return": {"result": 40},
+                "error": None,
+            },
+        ]
+        assert calls(other_package.write_to_disk) == [
+            {
+                "args": [{"result": 42}],
+                "kwargs": None,
+                "return": "Wrote to disk!",
+                "error": None,
+            },
+            {
+                "args": [{"result": 40}],
+                "kwargs": None,
+                "return": "Wrote to disk!",
+                "error": None,
+            },
+        ]
+        # assert False

--- a/tests/sample_code/test_my_module_with_bound_imports.py
+++ b/tests/sample_code/test_my_module_with_bound_imports.py
@@ -1,39 +1,39 @@
 from pybond import calls, called_with_args, spy, stub, times_called
 
 import sample_code.other_package as other_package
-import sample_code.my_module as my_module
-from sample_code.my_module import bar
+import sample_code.my_module_with_bound_imports as my_module_with_bound_imports
+from sample_code.my_module_with_bound_imports import bar
 from tests.sample_code.mocks import (
     mock_make_a_network_request,
     mock_write_to_disk,
 )
 
 
-def test_foo_is_called():
-    with spy((my_module, "foo")):
-        assert times_called(my_module.foo, 0)
+def test_foo_is_called_when_module_uses_bound_imports():
+    with spy((my_module_with_bound_imports, "foo")):
+        assert times_called(my_module_with_bound_imports.foo, 0)
         bar(42)
-        assert times_called(my_module.foo, 1)
+        assert times_called(my_module_with_bound_imports.foo, 1)
         bar(42)
         bar(42)
-        assert times_called(my_module.foo, 3)
+        assert times_called(my_module_with_bound_imports.foo, 3)
 
 
-def test_bar_handles_response():
+def test_bar_handles_response_when_module_uses_bound_imports():
     with stub(
         (other_package, "make_a_network_request", mock_make_a_network_request),
         (other_package, "write_to_disk", mock_write_to_disk),
     ), spy(
-        (my_module, "foo"),
+        (my_module_with_bound_imports, "foo"),
     ):
-        assert times_called(my_module.foo, 0)
+        assert times_called(my_module_with_bound_imports.foo, 0)
         assert times_called(other_package.make_a_network_request, 0)
         assert bar(21) == {"result": 42}
-        assert times_called(my_module.foo, 1)
+        assert times_called(my_module_with_bound_imports.foo, 1)
         assert times_called(other_package.make_a_network_request, 1)
-        assert called_with_args(my_module.foo, args=[21])
+        assert called_with_args(my_module_with_bound_imports.foo, args=[21])
         assert bar(20) == {"result": 40}
-        assert calls(my_module.foo) == [
+        assert calls(my_module_with_bound_imports.foo) == [
             {
                 "args": [21],
                 "kwargs": None,


### PR DESCRIPTION
**Changes:**

- **Breaking:** the `check_function_signatures` optional argument has been renamed to `strict`, in anticipation of better support, in the future, for stubbing and spying on objects that are not functions.
- Better type hints
  - The `stub` and `spy` context managers, more appropriately, now expect tuples rather than lists.
- Support stubbing and spying on objects imported using `from m import obj` syntax
  - This uses the garbage collector to find references to the original objects, which are then replaced using the `setitem()` method of the `MonkeyPatch` context. This sounds like not such a great idea, but it seems to work, and I don't know of a better way to accomplish this.
