### PR TITLE
Simplify api for specifying spy or stub targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ from sample_code.my_module import bar
 
 
 def test_foo_is_called():
-    with spy((my_module, "foo")):
+    with spy(my_module.foo):
         assert times_called(my_module.foo, 0)
         bar(42)
         assert times_called(my_module.foo, 1)
@@ -71,10 +71,10 @@ def test_foo_is_called():
 
 def test_bar_handles_response():
     with stub(
-        (other_package, "make_a_network_request", lambda x: {"result": x * 2}),
-        (other_package, "write_to_disk", lambda _: None),
+        (other_package.make_a_network_request, lambda x: {"result": x * 2}),
+        (other_package.write_to_disk, lambda _: None),
     ), spy(
-        (my_module, "foo"),
+        my_module.foo,
     ):
         assert times_called(my_module.foo, 0)
         assert times_called(other_package.make_a_network_request, 0)

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@
 pip
 
 ```bash
-pip install pybond==0.1.9
+pip install pybond==0.2.0
 ```
 
 requirements.txt
 
 ```python
-pybond==0.1.9
+pybond==0.2.0
 ```
 
 pyproject.toml
 
 ```toml
-pybond = "0.1.9"
+pybond = "0.2.0"
 ```
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ from sample_code.my_module import bar
 
 
 def test_foo_is_called():
-    with spy([my_module, "foo"]):
+    with spy((my_module, "foo")):
         assert times_called(my_module.foo, 0)
         bar(42)
         assert times_called(my_module.foo, 1)
@@ -71,10 +71,10 @@ def test_foo_is_called():
 
 def test_bar_handles_response():
     with stub(
-        [other_package, "make_a_network_request", lambda x: {"result": x * 2}],
-        [other_package, "write_to_disk", lambda _: None],
+        (other_package, "make_a_network_request", lambda x: {"result": x * 2}),
+        (other_package, "write_to_disk", lambda _: None),
     ), spy(
-        [my_module, "foo"],
+        (my_module, "foo"),
     ):
         assert times_called(my_module.foo, 0)
         assert times_called(other_package.make_a_network_request, 0)

--- a/pybond/types.py
+++ b/pybond/types.py
@@ -1,4 +1,3 @@
-from types import ModuleType
 from typing import Any, Callable, Tuple, TypeAlias, TypedDict
 
 FunctionCall = TypedDict(
@@ -11,6 +10,6 @@ FunctionCall = TypedDict(
     }
 )
 
-Spyable: TypeAlias = Callable | object
-SpyTarget: TypeAlias = Tuple[ModuleType, str]
-StubTarget: TypeAlias = Tuple[ModuleType, str, Spyable]
+Spyable: TypeAlias = Callable | Any
+SpyTarget: TypeAlias = Spyable
+StubTarget: TypeAlias = Tuple[Spyable, Spyable]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybond"
-version = "0.1.9"
+version = "0.2.0"
 description = "pybond is a spying and stubbing library inspired by the clojure bond library."
 authors = ["Guillaume Pelletier <guigui.p@gmail.com>"]
 license = "Eclipse Public License - v 1.0"

--- a/tests/pybond/test_assertions.py
+++ b/tests/pybond/test_assertions.py
@@ -19,10 +19,10 @@ def test_was_called():
         my_module.bar(42)
         assert was_called(my_module.foo)
 
-    with spy((my_module, "foo")):
+    with spy(my_module.foo):
         run_tests()
 
-    with stub((my_module, "foo", my_module.foo)):
+    with stub((my_module.foo, my_module.foo)):
         run_tests()
 
 
@@ -43,10 +43,10 @@ def test_times_called():
         my_module.bar(42)
         assert times_called(my_module.foo, 4)
 
-    with spy((my_module, "foo")):
+    with spy(my_module.foo):
         run_tests()
 
-    with stub((my_module, "foo", my_module.foo)):
+    with stub((my_module.foo, my_module.foo)):
         run_tests()
 
 
@@ -59,7 +59,7 @@ def test_times_called_throws_on_unspied_functions():
 
 def test_called_with_args():
     # When there is only one function call
-    with spy((other_package, "make_a_network_request")):
+    with spy(other_package.make_a_network_request):
         assert not called_with_args(
             other_package.make_a_network_request,
             args=[42, 12],
@@ -73,7 +73,7 @@ def test_called_with_args():
         )
 
     # When there are multiple function calls (order doesn't matter)
-    with spy((other_package, "make_a_network_request")):
+    with spy(other_package.make_a_network_request):
         other_package.make_a_network_request(0, y=None)
         other_package.make_a_network_request(0, y="elephant")
         other_package.make_a_network_request(42, 12, y="y", other_arg=True)
@@ -118,7 +118,7 @@ def test_called_with_args_throws_on_unspied_functions():
 
 def test_called_exactly_once_with_args():
     # When there is only one function call
-    with spy((other_package, "make_a_network_request")):
+    with spy(other_package.make_a_network_request):
         assert not called_exactly_once_with_args(
             other_package.make_a_network_request,
             args=[42, 12],
@@ -132,7 +132,7 @@ def test_called_exactly_once_with_args():
         )
 
     # When there are multiple function calls (order doesn't matter)
-    with spy((other_package, "make_a_network_request")):
+    with spy(other_package.make_a_network_request):
         other_package.make_a_network_request(0, y=None)
         other_package.make_a_network_request(0, y="elephant")
         other_package.make_a_network_request(42, 12, y="y", other_arg=True)
@@ -177,7 +177,7 @@ def test_called_exactly_once_with_args_throws_on_unspied_functions():
 
 def test_called_with_exact_args_list():
     # When there is only one function call
-    with spy((other_package, "make_a_network_request")):
+    with spy(other_package.make_a_network_request):
         assert not called_with_exact_args_list(
             other_package.make_a_network_request,
         )
@@ -189,7 +189,7 @@ def test_called_with_exact_args_list():
         )
 
     # When there are multiple function calls (order matters)
-    with spy((other_package, "make_a_network_request")):
+    with spy(other_package.make_a_network_request):
         other_package.make_a_network_request(0, y=None)
         other_package.make_a_network_request(0, y="elephant")
         other_package.make_a_network_request(42, 12, y="y", other_arg=True)

--- a/tests/pybond/test_james.py
+++ b/tests/pybond/test_james.py
@@ -20,45 +20,46 @@ def test_spied_function_throws_exception():
             ]
         )
 
-    with spy((other_package, "dangerous_function")):
+    with spy(other_package.dangerous_function):
         run_tests()
     
-    with stub((other_package, "dangerous_function", other_package.dangerous_function)):
+    with stub(
+        (other_package.dangerous_function, other_package.dangerous_function),
+    ):
         run_tests()
 
 
 @pytest.mark.parametrize(
-    "target_module, target_function, stub_fn, signature_matching",
+    "target, stub_fn, signature_matching",
     [
-        pytest.param(other_package, "write_to_disk", lambda: None, False),
-        pytest.param(other_package, "write_to_disk", lambda x: None, True),
-        pytest.param(other_package, "write_to_disk", lambda *x: None, False),
-        pytest.param(other_package, "write_to_disk", lambda **x: None, False),
-        pytest.param(other_package, "write_to_disk", lambda a, b: None, False),
-        pytest.param(other_package, "write_to_disk", lambda x, *a: None, False),
-        pytest.param(other_package, "write_to_disk", lambda x, **a: None, False),
+        pytest.param(other_package.write_to_disk, lambda: None, False),
+        pytest.param(other_package.write_to_disk, lambda x: None, True),
+        pytest.param(other_package.write_to_disk, lambda *x: None, False),
+        pytest.param(other_package.write_to_disk, lambda **x: None, False),
+        pytest.param(other_package.write_to_disk, lambda a, b: None, False),
+        pytest.param(other_package.write_to_disk, lambda x, *a: None, False),
+        pytest.param(other_package.write_to_disk, lambda x, **a: None, False),
     ],
 )
 def test_stub_function_signature_should_match(
-    target_module,
-    target_function,
+    target,
     stub_fn,
     signature_matching,
 ):
     if signature_matching:
-        with stub((target_module, target_function, stub_fn)):
+        with stub((target, stub_fn)):
             my_module.bar(42)
             assert True  # No exception is thrown in the line above
     else:
         with pytest.raises(Exception) as e:
-            with stub((target_module, target_function, stub_fn)):
+            with stub((target, stub_fn)):
                 my_module.bar(42)
         assert e.value.args[0].startswith("Stub does not match the signature of")
 
 
 def test_class_stubbing():
     mock_now = datetime.datetime.now()
-    with stub((datetime, "datetime", create_mock_datetime(mock_now))):
+    with stub((datetime.datetime, create_mock_datetime(mock_now))):
         time.sleep(2)
         assert (
             my_module.use_the_datetime_class_to_get_current_timestamp()

--- a/tests/sample_code/test_decorators.py
+++ b/tests/sample_code/test_decorators.py
@@ -3,5 +3,5 @@ import sample_code.decorators as decorators
 
 
 def test_decorated_functions():
-    with stub((decorators, "my_adder", lambda a, b: a * b)):
+    with stub((decorators.my_adder, lambda a, b: a * b)):
         assert decorators.my_adder(2, 3) == 6

--- a/tests/sample_code/test_my_module.py
+++ b/tests/sample_code/test_my_module.py
@@ -10,7 +10,7 @@ from tests.sample_code.mocks import (
 
 
 def test_foo_is_called():
-    with spy((my_module, "foo")):
+    with spy(my_module.foo):
         assert times_called(my_module.foo, 0)
         bar(42)
         assert times_called(my_module.foo, 1)
@@ -21,10 +21,10 @@ def test_foo_is_called():
 
 def test_bar_handles_response():
     with stub(
-        (other_package, "make_a_network_request", mock_make_a_network_request),
-        (other_package, "write_to_disk", mock_write_to_disk),
+        (other_package.make_a_network_request, mock_make_a_network_request),
+        (other_package.write_to_disk, mock_write_to_disk),
     ), spy(
-        (my_module, "foo"),
+        my_module.foo,
     ):
         assert times_called(my_module.foo, 0)
         assert times_called(other_package.make_a_network_request, 0)

--- a/tests/sample_code/test_my_module_with_bound_imports.py
+++ b/tests/sample_code/test_my_module_with_bound_imports.py
@@ -10,7 +10,7 @@ from tests.sample_code.mocks import (
 
 
 def test_foo_is_called_when_module_uses_bound_imports():
-    with spy((my_module_with_bound_imports, "foo")):
+    with spy(my_module_with_bound_imports.foo):
         assert times_called(my_module_with_bound_imports.foo, 0)
         bar(42)
         assert times_called(my_module_with_bound_imports.foo, 1)
@@ -21,10 +21,10 @@ def test_foo_is_called_when_module_uses_bound_imports():
 
 def test_bar_handles_response_when_module_uses_bound_imports():
     with stub(
-        (other_package, "make_a_network_request", mock_make_a_network_request),
-        (other_package, "write_to_disk", mock_write_to_disk),
+        (other_package.make_a_network_request, mock_make_a_network_request),
+        (other_package.write_to_disk, mock_write_to_disk),
     ), spy(
-        (my_module_with_bound_imports, "foo"),
+        my_module_with_bound_imports.foo,
     ):
         assert times_called(my_module_with_bound_imports.foo, 0)
         assert times_called(other_package.make_a_network_request, 0)


### PR DESCRIPTION
**Changes:**

- Previously, to specify a spy or stub target, you would have to pass in the module and a string referencing a module's attribute. This seems unnecessarily complicated, especially considering that the calls() API (and other similar utilities) require only a direct reference to the spied/stubbed target.
  - `spy()` is now invoked by passing in a simple list of targets
  - `stub()` is now invoked by passing in two-tuples instead of three-tuples

**Checklist / Reminders**

- [ ] Tests have been added and give confidence that the code is working.
