### PR TITLE
Guard against infinite recursion when using deepcopy on spied function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@
 pip
 
 ```bash
-pip install pybond==0.2.0
+pip install pybond==0.2.1
 ```
 
 requirements.txt
 
 ```python
-pybond==0.2.0
+pybond==0.2.1
 ```
 
 pyproject.toml
 
 ```toml
-pybond = "0.2.0"
+pybond = "0.2.1"
 ```
 
 ## Example usage


### PR DESCRIPTION
**Changes:**

- Use a try...except block to guard against infinite recursion when using deepcopy on spied function arguments

**Rationale & Considerations**

This came up when trying to spy on a function that took a boto3 S3ServiceResource object as an argument.

**Checklist / Reminders**

- [ ] Tests have been added and give confidence that the code is working.
